### PR TITLE
SPK-31644 Update dashed metro encoding

### DIFF
--- a/lib/data/METRO_CODE_TO_NAME.yml
+++ b/lib/data/METRO_CODE_TO_NAME.yml
@@ -1,72 +1,72 @@
 ---
 4: Abilene
 6: Aguadilla
-7: Boston_Worcester_Lawrence
+7: Boston-Worcester-Lawrence
 12: Albany
-14: Chicago_Gary_Kenosha
-16: Albany_Schenectady_Troy
+14: Chicago-Gary-Kenosha
+16: Albany-Schenectady-Troy
 20: Albuquerque
-21: Cincinnati_Hamilton
+21: Cincinnati-Hamilton
 22: Alexandria
-24: Allentown_Bethlehem_Easton
+24: Allentown-Bethlehem-Easton
 27: Altoona
-28: Cleveland_Akron
-31: Dallas_Fort Worth
+28: Cleveland-Akron
+31: Dallas-Fort Worth
 32: Amarillo
-34: Denver_Boulder_Greeley
-35: Detroit_Ann Arbor_Flint
+34: Denver-Boulder-Greeley
+35: Detroit-Ann Arbor-Flint
 38: Anchorage
-42: Houston_Galveston_Brazoria
+42: Houston-Galveston-Brazoria
 45: Anniston
-46: Appleton_Oshkosh_Neenah
+46: Appleton-Oshkosh-Neenah
 48: Asheville
-49: Los Angeles_Riverside_Orange County
+49: Los Angeles-Riverside-Orange County
 50: Athens
 52: Atlanta
-56: Miami_Fort Lauderdale
-58: Auburn_Opelika
-60: Augusta_Aiken
-63: Milwaukee_Racine
-64: Austin_San Marcos
+56: Miami-Fort Lauderdale
+58: Auburn-Opelika
+60: Augusta-Aiken
+63: Milwaukee-Racine
+64: Austin-San Marcos
 68: Bakersfield
-70: New York_Northern New Jersey_Long Island
+70: New York-Northern New Jersey-Long Island
 73: Bangor
-74: Barnstable_Yarmouth
+74: Barnstable-Yarmouth
 76: Baton Rouge
-77: Philadelphia_Wilmington_Atlantic City
-79: Portland_Vancouver
-82: Sacramento_Yolo
-83: Beaumont_Port Arthur
-84: San Francisco_Oakland_San Jose
+77: Philadelphia-Wilmington-Atlantic City
+79: Portland-Vancouver
+82: Sacramento-Yolo
+83: Beaumont-Port Arthur
+84: San Francisco-Oakland-San Jose
 86: Bellingham
 87: Benton Harbor
-89: San Juan_Caguas_Arecibo
+89: San Juan-Caguas-Arecibo
 88: Billings
-91: Seattle_Tacoma_Bremerton
-92: Biloxi_Gulfport_Pascagoula
+91: Seattle-Tacoma-Bremerton
+92: Biloxi-Gulfport-Pascagoula
 96: Binghamton
-97: Washington_Baltimore
+97: Washington-Baltimore
 100: Birmingham
 101: Bismarck
 102: Bloomington
-104: Bloomington_Normal
+104: Bloomington-Normal
 108: Boise
-124: Brownsville_Harlingen_San Benito
-126: Bryan_College Station
-128: Buffalo_Niagara Falls
+124: Brownsville-Harlingen-San Benito
+126: Bryan-College Station
+128: Buffalo-Niagara Falls
 130: Burlington
-132: Canton_Massillon
+132: Canton-Massillon
 135: Casper
 136: Cedar Rapids
-140: Champaign_Urbana
-144: Charleston_North Charleston
+140: Champaign-Urbana
+144: Charleston-North Charleston
 148: Charleston
-152: Charlotte_Gastonia_Rock Hill
+152: Charlotte-Gastonia-Rock Hill
 154: Charlottesville
 156: Chattanooga
 158: Cheyenne
-162: Chico_Paradise
-166: Clarksville_Hopkinsville
+162: Chico-Paradise
+166: Clarksville-Hopkinsville
 172: Colorado Springs
 174: Columbia
 176: Columbia
@@ -76,8 +76,8 @@
 189: Corvallis
 190: Cumberland
 195: Danville
-196: Davenport_Moline_Rock Island
-200: Dayton_Springfield
+196: Davenport-Moline-Rock Island
+200: Dayton-Springfield
 202: Daytona Beach
 203: Decatur
 204: Decatur
@@ -85,24 +85,24 @@
 218: Dothan
 219: Dover
 220: Dubuque
-224: Duluth_Superior
+224: Duluth-Superior
 229: Eau Claire
 232: El Paso
-233: Elkhart_Goshen
+233: Elkhart-Goshen
 234: Elmira
 235: Enid
 236: Erie
-240: Eugene_Springfield
-244: Evansville_Henderson
-252: Fargo_Moorhead
+240: Eugene-Springfield
+244: Evansville-Henderson
+252: Fargo-Moorhead
 256: Fayetteville
-258: Fayetteville_Springdale_Rogers
+258: Fayetteville-Springdale-Rogers
 262: Flagstaff
 265: Florence
 266: Florence
-267: Fort Collins_Loveland
-270: Fort Myers_Cape Coral
-271: Fort Pierce_Port St. Lucie
+267: Fort Collins-Loveland
+270: Fort Myers-Cape Coral
+271: Fort Pierce-Port St. Lucie
 272: Fort Smith
 275: Fort Walton Beach
 276: Fort Wayne
@@ -113,19 +113,19 @@
 294: Goldsboro
 296: Grand Forks
 298: Grand Junction
-300: Grand Rapids_Muskegon_Holland
+300: Grand Rapids-Muskegon-Holland
 304: Great Falls
 308: Green Bay
-312: Greensboro_Winston Salem_High Point
+312: Greensboro-Winston Salem-High Point
 315: Greenville
-316: Greenville_Spartanburg_Anderson
-324: Harrisburg_Lebanon_Carlisle
+316: Greenville-Spartanburg-Anderson
+324: Harrisburg-Lebanon-Carlisle
 327: Hartford
 328: Hattiesburg
-329: Hickory_Morganton_Lenoir
+329: Hickory-Morganton-Lenoir
 332: Honolulu
 335: Houma
-340: Huntington_Ashland
+340: Huntington-Ashland
 344: Huntsville
 348: Indianapolis
 350: Iowa City
@@ -135,34 +135,34 @@
 359: Jacksonville
 360: Jacksonville
 361: Jamestown
-362: Janesville_Beloit
-366: Johnson City_Kingsport_Bristol
+362: Janesville-Beloit
+366: Johnson City-Kingsport-Bristol
 368: Johnstown
 370: Jonesboro
 371: Joplin
-372: Kalamazoo_Battle Creek
+372: Kalamazoo-Battle Creek
 376: Kansas City
-381: Killeen_Temple
+381: Killeen-Temple
 384: Knoxville
 385: Kokomo
 387: La Crosse
 388: Lafayette
 392: Lafayette
 396: Lake Charles
-398: Lakeland_Winter Haven
+398: Lakeland-Winter Haven
 400: Lancaster
-404: Lansing_East Lansing
+404: Lansing-East Lansing
 408: Laredo
 410: Las Cruces
 412: Las Vegas
 415: Lawrence
 420: Lawton
-424: Lewiston_Auburn
+424: Lewiston-Auburn
 428: Lexington
 432: Lima
 436: Lincoln
-440: Little Rock_North Little Rock
-442: Longview_Marshall
+440: Little Rock-North Little Rock
+442: Longview-Marshall
 452: Louisville
 460: Lubbock
 464: Lynchburg
@@ -170,12 +170,12 @@
 472: Madison
 480: Mansfield
 484: Mayaguez
-488: Mcallen_Edinburg_Mission
-489: Medford_Ashland
-490: Melbourne_Titusville_Palm Bay
+488: Mcallen-Edinburg-Mission
+489: Medford-Ashland
+490: Melbourne-Titusville-Palm Bay
 492: Memphis
 494: Merced
-512: Minneapolis_St. Paul
+512: Minneapolis-St. Paul
 514: Missoula
 516: Mobile
 517: Modesto
@@ -185,61 +185,61 @@
 533: Myrtle Beach
 534: Naples
 536: Nashville
-552: New London_Norwich
+552: New London-Norwich
 556: New Orleans
-572: Norfolk_Virginia Beach_Newport News
+572: Norfolk-Virginia Beach-Newport News
 579: Ocala
-580: Odessa_Midland
+580: Odessa-Midland
 588: Oklahoma City
 592: Omaha
 596: Orlando
 599: Owensboro
 601: Panama City
-602: Parkersburg_Marietta
+602: Parkersburg-Marietta
 608: Pensacola
-612: Peoria_Pekin
-620: Phoenix_Mesa
+612: Peoria-Pekin
+620: Phoenix-Mesa
 624: Pine Bluff
 628: Pittsburgh
 632: Pittsfield
 634: Pocatello
 636: Ponce
 640: Portland
-648: Providence_Fall River_Warwick
-652: Provo_Orem
+648: Providence-Fall River-Warwick
+652: Provo-Orem
 656: Pueblo
 658: Punta Gorda
-664: Raleigh_Durham_Chapel Hill
+664: Raleigh-Durham-Chapel Hill
 666: Rapid City
 668: Reading
 669: Redding
 672: Reno
-674: Richland_Kennewick_Pasco
-676: Richmond_Petersburg
+674: Richland-Kennewick-Pasco
+676: Richmond-Petersburg
 680: Roanoke
 682: Rochester
 684: Rochester
 688: Rockford
 689: Rocky Mount
-696: Saginaw_Bay City_Midland
+696: Saginaw-Bay City-Midland
 698: St. Cloud
 700: St. Joseph
 704: St. Louis
 712: Salinas
-716: Salt Lake City_Ogden
+716: Salt Lake City-Ogden
 720: San Angelo
 724: San Antonio
 732: San Diego
-746: San Luis Obispo_Atascadero_Paso Robles
-748: Santa Barbara_Santa Maria_Lompoc
+746: San Luis Obispo-Atascadero-Paso Robles
+748: Santa Barbara-Santa Maria-Lompoc
 749: Santa Fe
-751: Sarasota_Bradenton
+751: Sarasota-Bradenton
 752: Savannah
-756: Scranton_Wilkes Barre_Hazleton
+756: Scranton-Wilkes Barre-Hazleton
 761: Sharon
 762: Sheboygan
-764: Sherman_Denison
-768: Shreveport_Bossier City
+764: Sherman-Denison
+768: Shreveport-Bossier City
 772: Sioux City
 776: Sioux Falls
 780: South Bend
@@ -248,12 +248,12 @@
 792: Springfield
 800: Springfield
 805: State College
-808: Steubenville_Weirton
-812: Stockton_Lodi
+808: Steubenville-Weirton
+812: Stockton-Lodi
 814: Sumter
 816: Syracuse
 824: Tallahassee
-828: Tampa_St. Petersburg_Clearwater
+828: Tampa-St. Petersburg-Clearwater
 832: Terre Haute
 836: Texarkana
 840: Toledo
@@ -262,13 +262,13 @@
 856: Tulsa
 860: Tuscaloosa
 864: Tyler
-868: Utica_Rome
+868: Utica-Rome
 875: Victoria
-878: Visalia_Tulare_Porterville
+878: Visalia-Tulare-Porterville
 880: Waco
-892: Waterloo_Cedar Falls
+892: Waterloo-Cedar Falls
 894: Wausau
-896: West Palm Beach_Boca Raton
+896: West Palm Beach-Boca Raton
 900: Wheeling
 904: Wichita
 908: Wichita Falls
@@ -276,6 +276,6 @@
 920: Wilmington
 926: Yakima
 928: York
-932: Youngstown_Warren
+932: Youngstown-Warren
 934: Yuba City
 936: Yuma


### PR DESCRIPTION
Duplicate of [pull/15](https://github.com/Spokeo/geolookup/pull/15). Reverted due to dependency issues with Pesto NameSEO release.