### PR TITLE
SPK-68327: add Greenfield & Glendale WI to CITIES.yml

### DIFF
--- a/lib/data/CITIES.yml
+++ b/lib/data/CITIES.yml
@@ -4069,6 +4069,7 @@ glendale:
     - {state: ut, county: kane}
     - {state: ma, county: berkshire}
     - {state: ny, county: queens}
+    - {state: wi, county: milwaukee}
 goodyear:
     - {state: az, county: maricopa}
 higley:
@@ -9741,6 +9742,7 @@ greenfield:
     - {state: il, county: macoupin}
     - {state: in, county: shelby}
     - {state: oh, county: ross}
+    - {state: wi, county: milwaukee}
 'king city':
     - {state: ca, county: monterey}
     - {state: mo, county: gentry}


### PR DESCRIPTION
## Description

Adds the missing `{state: wi, county: milwaukee}` pairing to the `greenfield` and `glendale` entries in `lib/data/CITIES.yml`. Both are real Milwaukee-County, WI suburbs (Greenfield ~37k, Glendale ~13k) that were absent from the gem's city data.

## Why (root cause — Spokeo SPK-68327)

B2B customers reported that `"Jose Bartolomei, Greenfield WI"` and `"Anne Weber, Glendale WI"` search as the wrong person. Confirmed root cause is here in geolookup, not in the webapp:

- Spokeo's `QueryNormalizer.city_at_the_end` only accepts a trailing token as a city if `Geolookup::USA::City.find_cities_by_name` returns an entry **paired with the detected state**.
- `greenfield` and `glendale` existed in `CITIES.yml` but with **no `wi` pairing** (Greenfield: ca, ia, il, in, ma, mo, nh, oh, ok, tn; Glendale: az, ca, ky, ma, ny, oh, or, ri, sc, ut). `milwaukee` *does* have a `wi` pairing — which is why `"... Milwaukee WI"` already parsed correctly.
- With no WI match, the webapp left "Greenfield"/"Glendale" inside the name portion, and the trailing comma then triggered `<Last, First Middle>` name inversion in the `normalization` gem → **name order scrambled** (`first=Greenfield, middle=Jose, last=Bartolomei`).

### Verification

Before (installed gem):
```
greenfield: states=[ca,ia,il,in,ma,mo,nh,oh,ok,tn]  has_wi=false
glendale:   states=[az,ca,ky,ma,ny,oh,or,ri,sc,ut]  has_wi=false
```

After this change, `QueryNormalizer.parse_name_city_state` returns the correct parse:
```
"Jose Bartolomei, Greenfield WI" => {last_name: bartolomei, first_name: jose, city: greenfield, state: wisconsin}
"Anne Weber, Glendale WI"        => {last_name: weber,      first_name: anne, city: glendale,   state: wisconsin}
```
`YAML.load_file` still parses (20,035 keys); only two lines added.

## Scope / follow-up

This is the **targeted unblock** for the two reported cities, kept as a draft. It does **not** address the broader gap: mid-size suburbs are systematically underrepresented in `CITIES.yml` (even `ZIP_TO_CITY_STATE.yml` maps Greenfield's own zips 53220/53221 to `WI,Milwaukee`). A systematic backfill — or replacing the city dataset with an authoritative source (Census incorporated places + CDPs) — is the real fix and is tracked separately. The webapp-side parser hardening (not letting a comma reach name inversion when a location was intended) is also tracked under SPK-68327 so parsing degrades gracefully when a city is still missing.

Ticket: https://spokeo.atlassian.net/browse/SPK-68327